### PR TITLE
Amend codefresh pipeline to push auto-generated reports to new branch

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -13,7 +13,7 @@ steps:
     arguments:
       repo: 'kostis-codefresh/codefresh-plugin-checker'
       git: github-1
-      revision: 'master'  
+      revision: 'master'
   run_unit_tests:
     title: Running unit tests
     stage: test
@@ -40,7 +40,7 @@ steps:
     commands:
       - go run . step-info.json
     environment:
-    - GOPATH=/codefresh/volume/go    
+    - GOPATH=/codefresh/volume/go
   upload_report:
     title: Uploading report
     stage: report
@@ -48,10 +48,11 @@ steps:
     working_directory: ${{my_clone}}
     commands:
       - git config --global user.email "kostis@codefresh.io"
-      - git config --global user.name "Kostis Kapelonis" 
+      - git config --global user.name "Kostis Kapelonis"
+      - git co origin/gh-pages gh-pages
+      - git merge origin/master
       - git add docs/*
       - git status
       - git commit -m "Automatic CI report"
-      - git push "https://kostis-codefresh:$GITHUB_TOKEN@github.com/kostis-codefresh/codefresh-plugin-checker" master 
+      - git push "https://kostis-codefresh:$GITHUB_TOKEN@github.com/kostis-codefresh/codefresh-plugin-checker" gh-pages
       - echo "Report is ready at https://kostis-codefresh.github.io/codefresh-plugin-checker/"
-    


### PR DESCRIPTION
Please keep in mind that you need to change the branch github pages uses to serve this repo to the branch name `gh-pages`.

Related to issue #1