### PR TITLE
Add a feature to prepare Docker base image before searching the registry

### DIFF
--- a/analyze-steps.go
+++ b/analyze-steps.go
@@ -137,13 +137,13 @@ func storeImageInfo(fullDockerImage string, p *parsingContext) {
 
 	if strings.Contains(fullDockerImage, ":") {
 		imageAndTag := strings.Split(fullDockerImage, ":")
-		dockerImage.BaseImage = imageAndTag[0]
+		dockerImage.BaseImage = prepareBaseImage(imageAndTag[0])
 		dockerImage.HasTag = true
 		dockerImage.Tag = imageAndTag[1]
 
 	} else {
 		dockerImage.HasTag = false
-		dockerImage.BaseImage = fullDockerImage
+		dockerImage.BaseImage = prepareBaseImage(fullDockerImage)
 	}
 
 	//For tags with variables like $MY_TAG we will just check latest. For image names with variables

--- a/check-tag.go
+++ b/check-tag.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"strings"
 
 	"github.com/heroku/docker-registry-client/registry"
 )
@@ -37,5 +38,15 @@ func checkDockerImage(dockerHubConnection *registry.Registry, imageAndTag docker
 		}
 	}
 	return false
+}
 
+func prepareBaseImage(input string) string {
+	output := input
+	trimPrefixes := [1]string{"docker.io/"}
+
+	for _, prefix := range trimPrefixes {
+		output = strings.TrimPrefix(output, prefix)
+	}
+
+	return output
 }

--- a/check-tag_test.go
+++ b/check-tag_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckDockerImageWithValidImage(t *testing.T) {
+	imageAndTag := dockerImageName{
+		BaseImage: "codefresh/cf-sendmail",
+		HasTag:    true,
+		Tag:       "latest",
+	}
+
+	dockeHubConnection := connectToDockerHub()
+	foundInRegistry := checkDockerImage(dockeHubConnection, imageAndTag)
+
+	assert.True(t, foundInRegistry, "Should be found in docker registry")
+}
+
+func TestCheckDockerImageWithInvalidImage(t *testing.T) {
+	imageAndTag := dockerImageName{
+		BaseImage: "foo",
+		HasTag:    true,
+		Tag:       "bar",
+	}
+
+	dockeHubConnection := connectToDockerHub()
+	foundInRegistry := checkDockerImage(dockeHubConnection, imageAndTag)
+
+	assert.False(t, foundInRegistry, "Should be found in docker registry")
+}
+
+func TestPrepareBaseImageWithoutPrefixes(t *testing.T) {
+	output := prepareBaseImage("codefresh/cf-sendmail")
+
+	assert.EqualValues(t, "codefresh/cf-sendmail", output, "Should be the same")
+}
+
+func TestPrepareBaseImageWithDockerioPrefix(t *testing.T) {
+	output := prepareBaseImage("docker.io/codefresh/cf-sendmail")
+
+	assert.EqualValues(t, "codefresh/cf-sendmail", output, "Should remove 'docker.io/'")
+}


### PR DESCRIPTION
In detail:

- Removes prefixes found in a list of prefixes
- Add tests (code coverage from ~25% to ~90%)